### PR TITLE
Update patroni.yaml for pg_hba

### DIFF
--- a/snap/local/config/patroni.yaml
+++ b/snap/local/config/patroni.yaml
@@ -2,9 +2,10 @@ scope: "charmed-postgresql"
 namespace: "/postgresql-common/"
 name: postgresql
 
-raft:
-  data_dir: /var/snap/charmed-postgresql/common/raft
-  self_addr: '127.0.0.1:2222'
+#### deprecated
+#raft:
+#  data_dir: /var/snap/charmed-postgresql/common/raft
+#  self_addr: '127.0.0.1:2222'
 
 restapi:
   listen: 127.0.0.1:8008
@@ -26,12 +27,13 @@ bootstrap:
       remove_data_directory_on_diverged_timelines: true
       use_slots: true
       pg_hba:
-        - local   all             all                                     peer
-        - host    all             all             127.0.0.1/32            md5
-        - host    all             all             ::1/128                 md5
-        - local   replication     all                                     peer
+#        - local   all             all                                     peer
+#        - host    all             all             127.0.0.1/32            md5
+        - host    all             all             0.0.0.0/0            md5        
+#        - host    all             all             ::1/128                 md5
+#        - local   replication     all                                     peer
         - host    replication     all             127.0.0.1/32            md5
-        - host    replication     all             ::1/128                 md5
+#        - host    replication     all             ::1/128                 md5
 postgresql:
   listen: "*:5432"
   connect_address: 127.0.0.1:5432


### PR DESCRIPTION
pg_hba
- access for all ip's over md5
- disabled authentication over peer and IPv6
raft - deprecated