### PR TITLE
fix lint errors - update patroni.yaml

### DIFF
--- a/snap/local/config/patroni.yaml
+++ b/snap/local/config/patroni.yaml
@@ -28,7 +28,7 @@ bootstrap:
       pg_hba:
 #        - local   all             all                                     peer
 #        - host    all             all             127.0.0.1/32            md5
-        - host    all             all             0.0.0.0/0            md5        
+        - host    all             all             0.0.0.0/0               md5
 #        - host    all             all             ::1/128                 md5
 #        - local   replication     all                                     peer
         - host    replication     all             127.0.0.1/32            md5


### PR DESCRIPTION
fix lint
31:81     error    line too long (82 > 80 characters)  (line-length)
31:75     error    trailing spaces  (trailing-spaces)